### PR TITLE
TRA-11988 : Migration pour utiliser l'entrepôt de données comme source de vérité

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,5 @@ staticfiles/
 # custom
 public/
 .vscode
-src/temp_data/
+temp_data/*
+

--- a/src/data/data_extract.py
+++ b/src/data/data_extract.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from sqlalchemy import create_engine
 
 from data.utils import format_waste_codes
-from data.queries import bs_weekly_data_sql, accounts_weekly_stats_sql
 
 DB_ENGINE = create_engine(settings.WAREHOUSE_URL)
 SQL_PATH = settings.BASE_DIR / "data" / "sql"
@@ -24,99 +23,6 @@ def extract_dataset(sql_string: str) -> pl.DataFrame:
     logger.info("Loading stats duration: %s (query : %s)", time.time() - started_time, sql_string)
 
     return accounts_data_df
-
-
-###########
-
-
-def get_bs_data(
-    query_filename: str,
-    include_drafts: bool = False,
-    include_only_dangerous_waste: bool = True,
-) -> pl.DataFrame:
-    """
-    Queries the configured database for BSx data. The query should select the columns needed to
-    create the figures of the application.
-
-    Parameters
-    ----------
-    query_filename: str
-        Name of the sql query file. Query must select at least a "created_at" column.
-    include_drafts: bool
-        Wether to include drafts BSx in the result.
-    include_only_dangerous_waste: bool
-        If true, only 'bordereaux' for dangerous waste are returned.
-
-    Returns
-    -------
-    DataFrame
-        DataFrame of BSx, with all data included in the sql query.
-    """
-
-    started_time = time.time()
-
-    sql_query = (SQL_PATH / query_filename).read_text()
-
-    bs_data_df = pl.read_sql(sql_query, connection_uri=settings.WAREHOUSE_URL)
-
-    if not include_drafts:
-        bs_data_df = bs_data_df.filter(pl.col("status") != "DRAFT")
-        if "is_draft" in bs_data_df.columns:
-            bs_data_df = bs_data_df.filter(pl.col("is_draft").is_not())
-    if include_only_dangerous_waste:
-        waste_filter = pl.col("waste_code").str.contains(pattern=r".*\*$")
-        if "waste_pop" in bs_data_df.columns:
-            waste_filter = waste_filter | pl.col("waste_pop")
-
-        if "waste_details_is_dangerous" in bs_data_df.columns:
-            waste_filter = waste_filter | pl.col("waste_details_is_dangerous")
-
-    # Depending on the type of 'bordereau', the processing operations codes can contain space or not, so we normalize it :
-    # bs_data_df = bs_data_df.with_columns(
-    #     pl.col("processing_operation").str.replace(r"([RD])([0-9]{1,2})", value="$1 $2")
-    # )
-
-    logger.info(f"get_bs_data duration: {time.time() - started_time} ({query_filename})")
-
-    return bs_data_df
-
-
-def get_company_data() -> pl.DataFrame:
-    """
-    Queries the configured database for company data.
-
-    Returns
-    -------
-    DataFrame
-        DataFrame of companies for a given period of time, with their creation date
-    """
-    started_time = time.time()
-
-    sql_query = (SQL_PATH / "get_company_data.sql").read_text()
-    company_data_df = pl.read_sql(sql_query, connection_uri=settings.WAREHOUSE_URL)
-
-    logger.info(f"get_company_data duration: {time.time() - started_time}")
-
-    return company_data_df
-
-
-def get_user_data() -> pl.DataFrame:
-    """
-    Queries the configured database for user data, focused on creation date.
-
-    Returns
-    --------
-    DataFrame
-        dataframe of users for a given period of time, with their creation date
-    """
-    started_time = time.time()
-
-    sql_query = (SQL_PATH / "get_user_data.sql").read_text()
-    user_data_df = pl.read_sql(sql_query, connection_uri=settings.WAREHOUSE_URL)
-
-    logger.info(f"get_user_data duration: {time.time() - started_time} ")
-
-    return user_data_df
 
 
 def get_processing_operation_codes_data() -> pl.DataFrame:
@@ -179,20 +85,3 @@ def get_waste_code_hierarchical_nomenclature() -> list[dict]:
         waste_code_hierarchy = json.load(f)
 
     return format_waste_codes(waste_code_hierarchy, add_top_level=True)
-
-
-def get_naf_nomenclature_data() -> pl.DataFrame:
-    """
-    Returns the NAF nomenclature.
-
-    Returns
-    --------
-    DataFrame
-        DataFrame with NAF nomenclature data.
-    """
-    data = pl.read_sql(
-        "SELECT * FROM trusted_zone_insee.nomenclature_activites_francaises",
-        connection_uri=settings.WAREHOUSE_URL,
-    )
-
-    return data

--- a/src/data/data_extract.py
+++ b/src/data/data_extract.py
@@ -7,12 +7,26 @@ from django.conf import settings
 from sqlalchemy import create_engine
 
 from data.utils import format_waste_codes
+from data.queries import bs_weekly_data_sql, accounts_weekly_stats_sql
 
 DB_ENGINE = create_engine(settings.WAREHOUSE_URL)
 SQL_PATH = settings.BASE_DIR / "data" / "sql"
 STATIC_DATA_PATH = settings.BASE_DIR / "data" / "static"
 
 logger = logging.getLogger(__name__)
+
+
+def extract_dataset(sql_string: str) -> pl.DataFrame:
+    started_time = time.time()
+
+    accounts_data_df = pl.read_sql(sql_string, connection_uri=settings.WAREHOUSE_URL)
+
+    logger.info("Loading stats duration: %s (query : %s)", time.time() - started_time, sql_string)
+
+    return accounts_data_df
+
+
+###########
 
 
 def get_bs_data(

--- a/src/data/data_processing.py
+++ b/src/data/data_processing.py
@@ -1,13 +1,10 @@
 """
 Data gathering and processing
 """
-from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Tuple
+from typing import Tuple
 
 import polars as pl
-
-from .data_extract import get_processing_operation_codes_data
 
 
 def get_weekly_preprocessed_dfs(
@@ -33,58 +30,6 @@ def get_weekly_preprocessed_dfs(
     bs_data_filtered = bs_data.filter(pl.col("semaine").is_between(*date_interval, closed="left")).sort("semaine")
 
     return bs_data_filtered
-
-
-def get_weekly_waste_quantity_processed_by_operation_code_df(
-    bs_data: pl.DataFrame, date_interval: tuple[datetime, datetime] | None = None
-) -> pl.DataFrame:
-    """
-    Creates a Polars multi-index Series with total weight of dangerous waste processed by week and by processing operation codes.
-    Processing operation codes that does not designate final operations are discarded.
-    Parameters
-    ----------
-    bs_data: DataFrame
-        DataFrame containing BSx data.
-    date_interval: tuple of two datetime objects
-        Optional. Interval of date used to filter the data as datetime objects.
-        First element is the start interval, the second one is the end of the interval.
-        The interval is left inclusive.
-
-    Returns
-    -------
-    Dataframe
-        Polars DataFrame containing aggregated data by week. Data is grouped on columns "processed_at" and "processing_operation".
-    """
-    date_filter = pl.col("processed_at").is_not_null()
-    if date_interval is not None:
-        date_filter = pl.col("processed_at").is_between(*date_interval, closed="left")
-
-    df = bs_data.filter(
-        date_filter
-        & pl.col("processing_operation")
-        .is_in(
-            [
-                "D9",
-                "D13",
-                "D14",
-                "D15",
-                "R12",
-                "R13",
-            ]
-        )
-        .is_not()
-        & pl.col("status").is_in(["PROCESSED", "FOLLOWED_WITH_PNTTD"])
-    )
-
-    df = (
-        df.with_columns(pl.col("processed_at").dt.truncate("1w"))
-        .sort("processed_at")
-        .groupby(["processed_at", "processing_operation"], maintain_order=True)
-        .agg(pl.col("quantity").sum())
-        .fill_null(0)
-    )
-
-    return df
 
 
 def get_recovered_and_eliminated_quantity_processed_by_week_series(
@@ -114,86 +59,6 @@ def get_recovered_and_eliminated_quantity_processed_by_week_series(
     ]
 
     return res
-
-
-def get_waste_quantity_processed_by_processing_code_df(
-    quantity_processed_weekly_df: pl.DataFrame,
-) -> pl.DataFrame:
-    """Adds the type of valorisation to the input DataFrame and sum waste quantities to have global quantity by processing operation code.
-
-    Parameters
-    ----------
-    quantity_processed_weekly_df: DataFrame
-        DataFrame containing total weight of dangerous waste processed by week and by processing operation codes.
-
-    Returns
-    -------
-    DataFrame
-        Aggregated quantity of processed weight by processing operation code along with the description of the processing operation
-         and type of processing operation.
-    """
-
-    processing_operations_codes_df = get_processing_operation_codes_data()
-    quantity_processed_weekly_df = quantity_processed_weekly_df.join(
-        processing_operations_codes_df, left_on="processing_operation", right_on="code"
-    )
-    agg_data = quantity_processed_weekly_df.groupby("processing_operation").agg(
-        [
-            pl.col("quantity").sum(),
-            pl.col("description").max().alias("processing_operation_description"),
-        ]
-    )
-
-    agg_data = agg_data.with_columns(
-        pl.col("processing_operation")
-        .apply(lambda x: "Déchet valorisé" if x.startswith("R") else "Déchet éliminé")
-        .alias("type_operation")
-    )
-
-    return agg_data
-
-
-def get_company_counts_by_naf_dfs(
-    company_data_df: pl.DataFrame,
-) -> Tuple[pl.DataFrame, pl.DataFrame]:
-    """
-    Builds two DataFrames used for the Treemap showing the company counts by company activities (code NAF):
-    - The first one is aggregated by "libelle_section", the outermost hierarchical level;
-    - The second one is aggregated by "libelle_division", the innermost hierarchical level chosen for the visualization.
-
-    Parameter
-    ---------
-    company_data_df: DataFrame
-        DataFrame containing company data along with NAF data.
-
-    Returns
-    -------
-    Tuple of two dataframes
-        One aggregated by "libelle_section" and one aggregated by "libelle_division".
-    """
-    company_data_df = company_data_df.with_columns(
-        [
-            pl.col("libelle_section").fill_null("Section NAF non renseignée."),
-            pl.col("libelle_division").fill_null("Division NAF non renseignée."),
-            pl.col("code_section").fill_null(""),
-            pl.col("code_division").fill_null(""),
-        ]
-    )
-
-    agg_data_1 = company_data_df.groupby("libelle_section").agg(
-        [pl.col("code_section").max(), pl.col("id").count().alias("num_entreprises")]
-    )
-
-    agg_data_2 = company_data_df.groupby("libelle_division").agg(
-        [
-            pl.col("code_division").max(),
-            pl.col("libelle_section").max(),
-            pl.col("code_section").max(),
-            pl.col("id").count().alias("num_entreprises"),
-        ]
-    )
-
-    return agg_data_1, agg_data_2
 
 
 def get_total_bs_created(
@@ -272,48 +137,3 @@ def get_total_number_of_accounts_created(
     number_of_accounts_created = accounts_data_df.select(stats_column).sum().item()
 
     return number_of_accounts_created
-
-
-def get_quantities_by_naf(
-    all_bordereaux_data_df: pl.DataFrame,
-    naf_nomenclature_data: pl.DataFrame,
-    date_interval: Tuple[datetime, datetime] | None = None,
-) -> pl.DataFrame:
-    """Takes a DataFrame of bordereaux data, a DataFrame with NAF nomenclature data, and an optional date
-    interval, and returns a DataFrame of bordereaux data with the naf nomenclature data joined to it using emitter SIRET as join key.
-
-    Parameters
-    ----------
-    all_bordereaux_data_df : pl.DataFrame
-        a DataFrame containing all the "bordereaux" data
-    naf_nomenclature_data : pl.DataFrame
-        a DataFrame containing the NAF nomenclature
-    date_interval : Tuple[datetime, datetime] | None
-        Tuple[datetime, datetime] | None = None
-
-    Returns
-    -------
-        A DataFrame with "bordereaux" data joined with NAF nomenclature.
-
-    """
-    all_bordereaux_data_df_with_naf = all_bordereaux_data_df.join(
-        naf_nomenclature_data,
-        left_on="emitter_naf",
-        right_on="code_sous_classe",
-        how="left",
-    )
-
-    all_bordereaux_data_df_with_naf = all_bordereaux_data_df_with_naf.filter(
-        pl.col("emitter_siret").is_in(pl.col("destination_siret")).is_not()
-    )
-
-    if date_interval is not None:
-        all_bordereaux_data_df_with_naf = all_bordereaux_data_df_with_naf.filter(
-            pl.col("sent_at").is_between(*date_interval, closed="left")
-        )
-
-    all_bordereaux_data_df_with_naf = all_bordereaux_data_df_with_naf.with_columns(
-        pl.col("emitter_naf").alias("code_sous_classe")
-    )
-
-    return all_bordereaux_data_df_with_naf

--- a/src/data/datasets.py
+++ b/src/data/datasets.py
@@ -18,39 +18,21 @@ from .data_extract import extract_dataset, get_bs_data
 
 @dataclass
 class Computed:
-    all_bsds_data: pl.DataFrame
-    bsdd_data: pl.DataFrame
-    bsdasri_data: pl.DataFrame
-    bsff_data: pl.DataFrame
-    bsda_data: pl.DataFrame
-
     bsdd_weekly_data: pl.DataFrame
     bsda_weekly_data: pl.DataFrame
     bsff_weekly_data: pl.DataFrame
     bsdasri_weekly_data: pl.DataFrame
+    bsvhu_weekly_data: pl.DataFrame
 
     accounts_weekly_data: pl.DataFrame
 
-    annual_waste_processed_data: pl.DataFrame
+    weekly_waste_processed_data: pl.DataFrame
 
     accounts_by_naf_data: pl.DataFrame
     waste_processed_by_naf_annual_stats: pl.DataFrame
 
 
 def get_data_df():
-    BSDD_DATA = get_bs_data(
-        "get_bsdd_data.sql",
-    )
-    BSDA_DATA = get_bs_data(
-        "get_bsda_data.sql",
-    )
-    BSFF_DATA = get_bs_data(
-        "get_bsff_data.sql",
-    )
-    BSDASRI_DATA = get_bs_data(
-        "get_bsdasri_data.sql",
-    )
-
     bsdd_weekly_data = extract_dataset(
         bs_weekly_data_sql.format("refined_zone_stats_publiques.bsdd_statistiques_hebdomadaires")
     )
@@ -63,6 +45,9 @@ def get_data_df():
     bsdasri_weekly_data = extract_dataset(
         bs_weekly_data_sql.format("refined_zone_stats_publiques.bsdasri_statistiques_hebdomadaires")
     )
+    bsvhu_weekly_data = extract_dataset(
+        bs_weekly_data_sql.format("refined_zone_stats_publiques.bsvhu_statistiques_hebdomadaires")
+    )
 
     accounts_weekly_data = extract_dataset(accounts_weekly_stats_sql)
 
@@ -71,19 +56,14 @@ def get_data_df():
     accounts_by_naf_data = extract_dataset(accounts_by_naf_annual_stats_sql)
     waste_processed_by_naf_annual_stats = extract_dataset(waste_processed_by_naf_annual_stats_sql)
 
-    all_bsd_data = pl.concat([BSDD_DATA, BSDA_DATA, BSFF_DATA, BSDASRI_DATA], how="diagonal")
     data = Computed(
-        all_bsds_data=all_bsd_data,
-        bsdd_data=BSDD_DATA,
-        bsdasri_data=BSDASRI_DATA,
-        bsff_data=BSFF_DATA,
-        bsda_data=BSDA_DATA,
         bsdd_weekly_data=bsdd_weekly_data,
         bsda_weekly_data=bsda_weekly_data,
         bsff_weekly_data=bsff_weekly_data,
         bsdasri_weekly_data=bsdasri_weekly_data,
+        bsvhu_weekly_data=bsvhu_weekly_data,
         accounts_weekly_data=accounts_weekly_data,
-        annual_waste_processed_data=annual_waste_processed_data,
+        weekly_waste_processed_data=weekly_waste_processed_data,
         accounts_by_naf_data=accounts_by_naf_data,
         waste_processed_by_naf_annual_stats=waste_processed_by_naf_annual_stats,
     )

--- a/src/data/datasets.py
+++ b/src/data/datasets.py
@@ -13,7 +13,7 @@ from data.queries import (
     weekly_waste_processed_stats_sql,
 )
 
-from .data_extract import extract_dataset, get_bs_data
+from .data_extract import extract_dataset
 
 
 @dataclass

--- a/src/data/datasets.py
+++ b/src/data/datasets.py
@@ -5,7 +5,15 @@ from dataclasses import dataclass
 
 import polars as pl
 
-from .data_extract import get_bs_data
+from data.queries import (
+    accounts_by_naf_annual_stats_sql,
+    accounts_weekly_stats_sql,
+    bs_weekly_data_sql,
+    waste_processed_by_naf_annual_stats_sql,
+    weekly_waste_processed_stats_sql,
+)
+
+from .data_extract import extract_dataset, get_bs_data
 
 
 @dataclass
@@ -15,6 +23,18 @@ class Computed:
     bsdasri_data: pl.DataFrame
     bsff_data: pl.DataFrame
     bsda_data: pl.DataFrame
+
+    bsdd_weekly_data: pl.DataFrame
+    bsda_weekly_data: pl.DataFrame
+    bsff_weekly_data: pl.DataFrame
+    bsdasri_weekly_data: pl.DataFrame
+
+    accounts_weekly_data: pl.DataFrame
+
+    annual_waste_processed_data: pl.DataFrame
+
+    accounts_by_naf_data: pl.DataFrame
+    waste_processed_by_naf_annual_stats: pl.DataFrame
 
 
 def get_data_df():
@@ -31,6 +51,26 @@ def get_data_df():
         "get_bsdasri_data.sql",
     )
 
+    bsdd_weekly_data = extract_dataset(
+        bs_weekly_data_sql.format("refined_zone_stats_publiques.bsdd_statistiques_hebdomadaires")
+    )
+    bsda_weekly_data = extract_dataset(
+        bs_weekly_data_sql.format("refined_zone_stats_publiques.bsda_statistiques_hebdomadaires")
+    )
+    bsff_weekly_data = extract_dataset(
+        bs_weekly_data_sql.format("refined_zone_stats_publiques.bsff_statistiques_hebdomadaires")
+    )
+    bsdasri_weekly_data = extract_dataset(
+        bs_weekly_data_sql.format("refined_zone_stats_publiques.bsdasri_statistiques_hebdomadaires")
+    )
+
+    accounts_weekly_data = extract_dataset(accounts_weekly_stats_sql)
+
+    weekly_waste_processed_data = extract_dataset(weekly_waste_processed_stats_sql)
+
+    accounts_by_naf_data = extract_dataset(accounts_by_naf_annual_stats_sql)
+    waste_processed_by_naf_annual_stats = extract_dataset(waste_processed_by_naf_annual_stats_sql)
+
     all_bsd_data = pl.concat([BSDD_DATA, BSDA_DATA, BSFF_DATA, BSDASRI_DATA], how="diagonal")
     data = Computed(
         all_bsds_data=all_bsd_data,
@@ -38,5 +78,13 @@ def get_data_df():
         bsdasri_data=BSDASRI_DATA,
         bsff_data=BSFF_DATA,
         bsda_data=BSDA_DATA,
+        bsdd_weekly_data=bsdd_weekly_data,
+        bsda_weekly_data=bsda_weekly_data,
+        bsff_weekly_data=bsff_weekly_data,
+        bsdasri_weekly_data=bsdasri_weekly_data,
+        accounts_weekly_data=accounts_weekly_data,
+        annual_waste_processed_data=annual_waste_processed_data,
+        accounts_by_naf_data=accounts_by_naf_data,
+        waste_processed_by_naf_annual_stats=waste_processed_by_naf_annual_stats,
     )
     return data

--- a/src/data/figures_factory.py
+++ b/src/data/figures_factory.py
@@ -11,9 +11,7 @@ from .page_utils import break_long_line, format_number
 gridcolor = "#ccc"
 
 
-def create_weekly_created_figure(
-    data: pl.DataFrame,
-) -> go.Figure:
+def create_weekly_created_figure(data: pl.DataFrame, stat_column: str) -> go.Figure:
     """Creates the figure showing number of weekly created companies, users...
 
     Parameters
@@ -26,40 +24,22 @@ def create_weekly_created_figure(
     Plotly Figure Object
         Figure object ready to be plotted.
     """
-    # Filter out data from previous year:
-    current_year = data["at"].max().year
-    data = data.filter(pl.col("at").dt.year() == current_year)
-
+    data = data.sort("semaine")
     data = data.to_dict(as_series=False)
 
     texts = []
-    texts += [""] * (len(data["count"]) - 1) + [format_number(data["count"][-1])]
+    texts += [""] * (len(data[stat_column]) - 1) + [format_number(data[stat_column][-1])]
 
     hovertexts = [
         f"Semaine du {at:%d/%m} au {at + timedelta(days=6):%d/%m}<br><b>{format_number(count)}</b> créations"
-        for at, count in zip(data["at"][:-1], data["count"][:-1])
+        for at, count in zip(data["semaine"], data[stat_column])
     ]
-
-    current_year = max(data["at"]).year
-
-    # Handle case when last data point is last week of the year
-    last_point_date = data["at"][-1]
-    last_point_value = data["count"][-1]
-    if (last_point_date + timedelta(days=6)).year != current_year:
-        last_point = datetime(current_year, 12, 31)
-        hovertexts.append(
-            f"Période du {last_point_date:%d/%m} au {last_point:%d/%m}<br><b>{format_number(last_point_value)}</b> créations"
-        )
-    else:
-        hovertexts.append(
-            f"Semaine du {last_point_date:%d/%m} au {last_point_date + timedelta(days=6):%d/%m}<br><b>{format_number(last_point_value)}</b> créations"
-        )
 
     fig = go.Figure(
         [
             go.Scatter(
-                x=data["at"],
-                y=data["count"],
+                x=data["semaine"],
+                y=data[stat_column],
                 text=texts,
                 mode="lines+markers+text",
                 hovertext=hovertexts,
@@ -74,9 +54,10 @@ def create_weekly_created_figure(
     )
 
     # handle ticks to start at first day of the first complete week of the year
-    min_x = min(data["at"])
-    max_x = max(data["at"])
+    min_x = min(data["semaine"])
+    max_x = max(data["semaine"])
 
+    current_year = max(data["semaine"]).year
     breaks = []
     for i in range(1, min_x.day):
         breaks.append(datetime(current_year, 1, i))
@@ -102,12 +83,8 @@ def create_weekly_created_figure(
 
 
 def create_weekly_scatter_figure(
-    bs_created_data: pl.DataFrame,
-    bs_sent_data: pl.DataFrame,
-    bs_received_data: pl.DataFrame,
-    bs_processed_data: pl.DataFrame,
-    bs_processed_non_final_data: pl.DataFrame,
-    bs_processed_final_data: pl.DataFrame,
+    bs_weekly_data: pl.DataFrame,
+    metric_type: str,
     bs_type: str,
     lines_configs: List[Dict[str, str]],
 ) -> go.Figure:
@@ -143,55 +120,90 @@ def create_weekly_scatter_figure(
     colors = ["#000091", "#5E2A2B", "#66673D", "#E4794A", "#60E0EB", "#009099"]
 
     plot_configs = [
-        {"data": bs_created_data, **lines_configs[0], "color": colors[0]},
+        {"column_counts": "creations", "column_quantity": "quantite_tracee", **lines_configs[0], "color": colors[0]},
         {
-            "data": bs_sent_data,
+            "column_counts": "envois",
+            "column_quantity": "quantite_envoyee",
             **lines_configs[1],
             "color": colors[1],
             "visible": "legendonly",
         },
-        {"data": bs_received_data, **lines_configs[2], "color": colors[2]},
-        {
-            "data": bs_processed_data,
-            **lines_configs[3],
-            "color": colors[3],
-        },
-        {
-            "data": bs_processed_non_final_data,
-            **lines_configs[4],
-            "color": colors[4],
-            "visible": "legendonly",
-        },
-        {
-            "data": bs_processed_final_data,
-            **lines_configs[5],
-            "color": colors[5],
-            "visible": "legendonly",
-        },
+        {"column_counts": "receptions", "column_quantity": "quantite_recue", **lines_configs[2], "color": colors[2]},
     ]
+
+    if bs_type != "BSFF":
+        plot_configs.extend(
+            [
+                {
+                    "column_counts": "traitements",
+                    "column_quantity": "quantite_traitee",
+                    **lines_configs[3],
+                    "color": colors[3],
+                },
+                {
+                    "column_counts": "traitements_operations_non_finales",
+                    "column_quantity": "quantite_traitee_operations_non_finales",
+                    **lines_configs[4],
+                    "color": colors[4],
+                    "visible": "legendonly",
+                },
+                {
+                    "column_counts": "traitements_operations_finales",
+                    "column_quantity": "quantite_traitee_operations_finales",
+                    **lines_configs[5],
+                    "color": colors[5],
+                    "visible": "legendonly",
+                },
+            ]
+        )
+    else:
+        plot_configs.extend(
+            [
+                {
+                    "column_counts": "contenants_traites",
+                    "column_quantity": "quantite_traitee",
+                    **lines_configs[3],
+                    "color": colors[3],
+                },
+                {
+                    "column_counts": "contenants_traites_operations_non_finales",
+                    "column_quantity": "quantite_traitee_operations_non_finales",
+                    **lines_configs[4],
+                    "color": colors[4],
+                    "visible": "legendonly",
+                },
+                {
+                    "column_counts": "contenants_traites_operations_finales",
+                    "column_quantity": "quantite_traitee_operations_finales",
+                    **lines_configs[5],
+                    "color": colors[5],
+                    "visible": "legendonly",
+                },
+            ]
+        )
 
     scatter_list = []
 
-    metric_name = "count" if "count" in bs_created_data.columns else "quantity"
-    y_title = "Quantité (en tonnes)" if metric_name == "quantity" else None
-    legend_title = "Statut :" if metric_name == "quantity" else "Statut du bordereau :"
+    y_title = "Quantité (en tonnes)" if metric_type == "quantity" else None
+    legend_title = "Statut :" if metric_type == "quantity" else "Statut du bordereau :"
     min_x = None
     max_x = None
     for config in plot_configs:
-        data = config["data"]
+        column_to_use = config["column_counts"] if metric_type == "counts" else config["column_quantity"]
+        data = bs_weekly_data
 
         if len(data) == 0:
             continue
 
         # Filter out data from previous year:
-        current_year = data.select("at").max().item().year
-        data = data.filter(pl.col("at").dt.year() == current_year)
+        current_year = data.select("semaine").max().item().year
+        data = data.filter(pl.col("semaine").dt.year() == current_year)
 
-        min_at = data["at"][0]
+        min_at = data["semaine"][0]
         if min_x is None or min_at < min_x:
             min_x = min_at
 
-        max_at = data["at"][-1]
+        max_at = data["semaine"][-1]
         if max_x is None or max_at > max_x:
             max_x = max_at
 
@@ -200,35 +212,26 @@ def create_weekly_scatter_figure(
 
         # Creates a list of text to only show value on last point of the line
         texts = []
-        last_value = data[-1, 1]
+        last_value = None
+        data_without_nulls = data.drop_nulls(column_to_use)
+        if len(data_without_nulls) > 0:
+            last_value = data_without_nulls[-1, column_to_use]
         texts = [""] * (len(data) - 1) if len(data) > 1 else []
         texts += [format_number(last_value)]
 
-        if metric_name == "count":
-            suffix = f"{bs_type} {suffix}"
+        if metric_type == "counts":
+            to_add_str = bs_type if bs_type != "BSFF" else "contenants"
+            suffix = f"{to_add_str} {suffix}"
 
         hover_texts = [
-            f"Semaine du {e[0]:%d/%m} au {e[0] + timedelta(days=6):%d/%m}<br><b>{format_number(e[1], 2)}</b> {suffix}"
-            for e in data[:-1].iter_rows()
+            f"Semaine du {e['semaine']:%d/%m} au {e['semaine'] + timedelta(days=6):%d/%m}<br><b>{format_number(e[column_to_use], 2)}</b> {suffix}"
+            for e in data.iter_rows(named=True)
         ]
-
-        # Handle case when last data point is last week of the year
-        last_point_date = data[-1]["at"].item()
-        last_point_value = data[-1][metric_name].item()
-        if (last_point_date + timedelta(days=6)).year != current_year:
-            last_point = datetime(current_year, 12, 31)
-            hover_texts.append(
-                f"Période du {last_point_date:%d/%m} au {last_point:%d/%m}<br><b>{format_number(last_point_value, 2)}</b> {suffix}"
-            )
-        else:
-            hover_texts.append(
-                f"Semaine du {last_point_date:%d/%m} au {last_point_date + timedelta(days=6):%d/%m}<br><b>{format_number(last_point_value, 2)}</b> {suffix}"
-            )
 
         scatter_list.append(
             go.Scatter(
-                x=data["at"],
-                y=data[metric_name],
+                x=data["semaine"],
+                y=data[column_to_use],
                 mode="lines+text",
                 name=name,
                 text=texts,
@@ -320,20 +323,22 @@ def create_weekly_quantity_processed_figure(
         data = conf["data"]
 
         # Filter out data from previous year:
-        current_year = data.select("processed_at").max().item().year
+        current_year = data.select("semaine").max().item().year
 
-        date_filter = pl.col("processed_at").dt.year() == current_year
+        date_filter = pl.col("semaine").dt.year() == current_year
         if date_interval is not None:
-            date_filter = pl.col("processed_at").is_between(*date_interval, closed="left")
+            date_filter = pl.col("semaine").is_between(*date_interval, closed="left")
+
         data = data.filter(date_filter)
+        data = data.sort("semaine")
 
         data = data.to_dict(as_series=False)
 
-        min_at = data["processed_at"][0]
+        min_at = data["semaine"][0]
         if min_x is None or min_at < min_x:
             min_x = min_at
 
-        max_at = data["processed_at"][-1]
+        max_at = data["semaine"][-1]
         if max_x is None or max_at > max_x:
             max_x = max_at
 
@@ -343,12 +348,12 @@ def create_weekly_quantity_processed_figure(
                 processed_at + timedelta(days=6),
                 format_number(quantity),
             )
-            for processed_at, quantity in zip(data["processed_at"][:-1], data["quantity"][:-1])
+            for processed_at, quantity in zip(data["semaine"][:-1], data["quantite_traitee"][:-1])
         ]
 
         # Handle case when last data point is last week of the year
-        last_point_date = data["processed_at"][-1]
-        last_point_value = data["quantity"][-1]
+        last_point_date = data["semaine"][-1]
+        last_point_value = data["quantite_traitee"][-1]
         if (last_point_date + timedelta(days=6)).year != current_year:
             last_point = datetime(current_year, 12, 31)
             hover_texts.append(
@@ -361,8 +366,8 @@ def create_weekly_quantity_processed_figure(
 
         traces.append(
             go.Bar(
-                x=data["processed_at"],
-                y=data["quantity"],
+                x=data["semaine"],
+                y=data["quantite_traitee"],
                 name=conf["name"],
                 hovertext=hover_texts,
                 hoverinfo="text",
@@ -374,7 +379,7 @@ def create_weekly_quantity_processed_figure(
 
     fig = go.Figure(data=traces)
 
-    max_value = sum([conf["data"]["quantity"].max() or 0 for conf in data_conf])
+    max_value = sum([conf["data"]["quantite_traitee"].max() or 0 for conf in data_conf])
 
     fig.update_layout(
         plot_bgcolor="rgba(0,0,0,0)",
@@ -388,7 +393,7 @@ def create_weekly_quantity_processed_figure(
             title="Type de traitement :",
             bgcolor="rgba(0,0,0,0)",
         ),
-        margin=dict(t=30, r=70, l=0),
+        margin=dict(t=30, r=70, l=20),
         barmode="stack",
         yaxis_title="Quantité (en tonnes)",
         yaxis_range=[0, max_value * 1.1],
@@ -410,7 +415,7 @@ def create_weekly_quantity_processed_figure(
 
 
 def create_quantity_processed_sunburst_figure(
-    waste_quantity_processed_by_processing_code_df: pl.DataFrame,
+    weekly_waste_processed_data_df: pl.DataFrame, date_interval: tuple[datetime, datetime]
 ) -> go.Figure:
     """Creates the figure showing the weekly waste quantity processed by type of processing operation (destroyed or recovered).
 
@@ -425,31 +430,39 @@ def create_quantity_processed_sunburst_figure(
         Sunburst Figure object ready to be plotted.
     """
 
-    agg_data = waste_quantity_processed_by_processing_code_df
-    total_data = agg_data.groupby("type_operation").agg(pl.col("quantity").sum()).sort("type_operation")
+    agg_data = (
+        weekly_waste_processed_data_df.filter(pl.col("semaine").is_between(*date_interval, closed="left"))
+        .groupby(["code_operation"])
+        .agg(pl.col("type_operation").max(), pl.col("quantite_traitee").sum())
+    )
+    total_data = agg_data.groupby("type_operation").agg(pl.col("quantite_traitee").sum()).sort("type_operation")
 
-    agg_data_recycled = agg_data.filter(pl.col("type_operation") == "Déchet valorisé").sort("quantity")
-    agg_data_eliminated = agg_data.filter(pl.col("type_operation") == "Déchet éliminé").sort("quantity")
+    agg_data_recycled = agg_data.filter(pl.col("type_operation") == "Déchet valorisé").sort("quantite_traitee")
+    agg_data_eliminated = agg_data.filter(pl.col("type_operation") == "Déchet éliminé").sort("quantite_traitee")
 
-    agg_data_recycled_other = agg_data_recycled.filter((pl.col("quantity") / pl.col("quantity").sum()) <= 0.12)
-    agg_data_eliminated_other = agg_data_eliminated.filter((pl.col("quantity") / pl.col("quantity").sum()) <= 0.21)
+    agg_data_recycled_other = agg_data_recycled.filter(
+        (pl.col("quantite_traitee") / pl.col("quantite_traitee").sum()) <= 0.12
+    )
+    agg_data_eliminated_other = agg_data_eliminated.filter(
+        (pl.col("quantite_traitee") / pl.col("quantite_traitee").sum()) <= 0.21
+    )
 
-    agg_data_recycled_other_quantity = agg_data_recycled_other["quantity"].sum()
-    agg_data_eliminated_other_quantity = agg_data_eliminated_other["quantity"].sum()
+    agg_data_recycled_other_quantity = agg_data_recycled_other["quantite_traitee"].sum()
+    agg_data_eliminated_other_quantity = agg_data_eliminated_other["quantite_traitee"].sum()
 
     other_processing_operations_codes = (
         pl.concat(
             [
-                agg_data_recycled_other.select("processing_operation"),
-                agg_data_eliminated_other.select("processing_operation"),
+                agg_data_recycled_other.select("code_operation"),
+                agg_data_eliminated_other.select("code_operation"),
             ]
         )
         .unique()
         .to_series()
     )
     agg_data_without_other = agg_data.filter(
-        pl.col("processing_operation").is_in(other_processing_operations_codes).is_not()
-    ).sort("quantity", descending=True)
+        pl.col("code_operation").is_in(other_processing_operations_codes).is_not()
+    ).sort("quantite_traitee", descending=True)
 
     agg_data_without_other = agg_data_without_other.with_columns(
         pl.col("type_operation")
@@ -461,15 +474,15 @@ def create_quantity_processed_sunburst_figure(
     agg_data_without_other = agg_data_without_other.to_dict(as_series=False)
     ids = (
         total_data["type_operation"]
-        + agg_data_without_other["processing_operation"]
+        + agg_data_without_other["code_operation"]
         + ["Autres opérations de valorisation", "Autres opérations d'élimination'"]
     )
 
-    labels = total_data["type_operation"] + agg_data_without_other["processing_operation"] + ["Autre"] * 2
+    labels = total_data["type_operation"] + agg_data_without_other["code_operation"] + ["Autre"] * 2
     parents = ["", ""] + agg_data_without_other["type_operation"] + ["Déchet valorisé", "Déchet éliminé"]
     values = (
-        total_data["quantity"]
-        + agg_data_without_other["quantity"]
+        total_data["quantite_traitee"]
+        + agg_data_without_other["quantite_traitee"]
         + [agg_data_recycled_other_quantity, agg_data_eliminated_other_quantity]
     )
     colors = (
@@ -478,22 +491,20 @@ def create_quantity_processed_sunburst_figure(
         + ["rgb(102, 103, 61, 0.7)", "rgb(94, 42, 43, 0.7)"]
     )
 
-    hover_text_template = "{code} : {description}<br><b>{quantity}t</b> traitées"
+    hover_text_template = "{code}<br><b>{quantity}t</b> traitées"
     hover_texts = (
         [
             f"<b>{format_number(e)}t</b> {index.split(' ')[1]}es"
-            for index, e in zip(total_data["type_operation"], total_data["quantity"])
+            for index, e in zip(total_data["type_operation"], total_data["quantite_traitee"])
         ]
         + [
             hover_text_template.format(
                 code=processing_operation,
-                description=processing_operation_description,
                 quantity=format_number(quantity),
             )
-            for processing_operation, processing_operation_description, quantity in zip(
-                agg_data_without_other["processing_operation"],
-                agg_data_without_other["processing_operation_description"],
-                agg_data_without_other["quantity"],
+            for processing_operation, quantity in zip(
+                agg_data_without_other["code_operation"],
+                agg_data_without_other["quantite_traitee"],
             )
         ]
         + [
@@ -528,7 +539,7 @@ def create_quantity_processed_sunburst_figure(
     return fig
 
 
-def create_treemap_companies_figure(data_with_naf: pl.DataFrame, use_quantity: bool = False) -> go.Figure:
+def create_treemap_companies_figure(data_with_naf: pl.DataFrame, year: int, use_quantity: bool = False) -> go.Figure:
     """Creates the figure showing the number of companies by NAF category.
 
     Parameters
@@ -638,33 +649,32 @@ def create_treemap_companies_figure(data_with_naf: pl.DataFrame, use_quantity: b
         schema=["libelle_section", "color"],
     )
 
-    df = data_with_naf
+    df = data_with_naf.filter(pl.col("annee") == year)
 
-    df = df.with_columns(
-        [
-            pl.col("code_section").fill_null("NAF inconnu"),
-            pl.col("libelle_section").fill_null("NAF inconnu"),
-        ]
-    )
+    df = df.fill_null("NAF inconnu")
 
     # Init values
-    total = df.height
-    value_expr = pl.col("id").count().alias("value")
+
+    stat_col = "nombre_etablissements"
+    value_expr = pl.col("nombre_etablissements").sum().alias("value")
     value_suffix = pl.lit("</b>")
     hover_expr_str = "</b> établissements inscrits dans la {label} NAF "
     hover_expr_lit_nulls = pl.lit("</b> établissements inscrits ayant un code NAF inconnu ")
     hover_expr_lit_end = pl.lit("%</b> du total des établissements inscrits.<extra></extra>")
-    labels = [f"Tous les établissements - <b>{total / 1000:.2f}k</b>"]
-    hover_texts = [f"Tous les établissements - <b>{total / 1000:.2f}k</b><extra></extra>"]
+    unit = ""
     if use_quantity:
-        total = df.select(pl.col("quantity").sum()).item()
-        value_expr = pl.col("quantity").sum().alias("value")
+        stat_col = "quantite_traitee"
+        value_expr = pl.col("quantite_traitee").sum().alias("value")
         value_suffix = pl.lit("t</b>")
         hover_expr_str = " tonnes</b> produites par des établissements inscrits dans la {label} NAF "
         hover_expr_lit_nulls = pl.lit(" tonnes</b> produites par des établissements ayant un code NAF inconnu ")
         hover_expr_lit_end = pl.lit("%</b> de la quantité totale produite.<extra></extra>")
-        labels = [f"Tous les établissements - <b>{total / 1000:.2f}kt</b>"]
-        hover_texts = [f"Tous les établissements - <b>{total / 1000:.2f}kt</b><extra></extra>"]
+        unit = "t"
+
+    total = df.select(stat_col).sum().item()
+
+    labels = [f"Tous les établissements - <b>{total / 1000:.2f}k{unit}</b>"]
+    hover_texts = [f"Tous les établissements - <b>{total / 1000:.2f}k{unit}</b><extra></extra>"]
 
     categories = ["sous_classe", "classe", "groupe", "division", "section"]
 

--- a/src/data/page_utils.py
+++ b/src/data/page_utils.py
@@ -6,6 +6,8 @@ import re
 
 def format_number(input_number: float, precision: int = 0) -> str:
     """Format a float to a string with thousands separated by space and rounding it at the given precision."""
+    if input_number is None:
+        return ""
     input_number = round(input_number, precision)
     return re.sub(r"\.0+", "", "{:,}".format(input_number).replace(",", " "))
 

--- a/src/data/queries.py
+++ b/src/data/queries.py
@@ -1,0 +1,41 @@
+bs_weekly_data_sql = """
+select
+    *
+from
+    {}
+where
+    semaine >= '2020-01-01'
+"""
+
+accounts_weekly_stats_sql = """
+select
+    *
+from
+    refined_zone_stats_publiques.accounts_created_by_week
+where
+    semaine >= '2020-01-01'
+"""
+
+weekly_waste_processed_stats_sql = """
+select
+    *
+from
+    refined_zone_stats_publiques.weekly_quantity_processed_stats
+where
+    annee >= 2020
+"""
+
+
+accounts_by_naf_annual_stats_sql = """
+select
+    *
+from
+    refined_zone_stats_publiques.annual_company_accounts_created_by_naf
+"""
+
+waste_processed_by_naf_annual_stats_sql = """
+select
+    *
+from
+    refined_zone_stats_publiques.annual_waste_processed_by_naf
+"""

--- a/src/data/queries.py
+++ b/src/data/queries.py
@@ -22,7 +22,7 @@ select
 from
     refined_zone_stats_publiques.weekly_quantity_processed_stats
 where
-    annee >= 2020
+    semaine >= '2020-01-01'
 """
 
 

--- a/src/data/queries.py
+++ b/src/data/queries.py
@@ -37,5 +37,5 @@ waste_processed_by_naf_annual_stats_sql = """
 select
     *
 from
-    refined_zone_stats_publiques.annual_waste_processed_by_naf
+    refined_zone_stats_publiques.annual_waste_produced_by_naf
 """

--- a/src/stats/management/commands/build_stats.py
+++ b/src/stats/management/commands/build_stats.py
@@ -15,6 +15,6 @@ class Command(BaseCommand):
 
         year = dt.date.today().year
         # build y-1 data if they don't exist
-        build_figs(year - 1)
+        build_figs(year - 1, clear_year=True)
         # build current year data
         build_figs(year, clear_year=True)

--- a/src/stats/processors/create_df.py
+++ b/src/stats/processors/create_df.py
@@ -16,21 +16,14 @@ def build_dataframes():
 
     bsd_data = get_data_df()
 
-    bsd_data.bsdd_data.write_json("temp_data/bsdd_data.json")
-    bsd_data.bsda_data.write_json("temp_data/bsda_data.json")
-    bsd_data.bsdasri_data.write_json("temp_data/bsdasri_data.json")
-    bsd_data.bsff_data.write_json("temp_data/bsff_data.json")
-    bsd_data.all_bsds_data.write_json("temp_data/all_bsds_data.json")
-    get_company_data().write_json("temp_data/company_data.json")
-    get_user_data().write_json("temp_data/user_data.json")
-
     for dataset_name in [
         "bsdd_weekly_data",
         "bsda_weekly_data",
         "bsff_weekly_data",
         "bsdasri_weekly_data",
+        "bsvhu_weekly_data",
         "accounts_weekly_data",
-        "annual_waste_processed_data",
+        "weekly_waste_processed_data",
         "accounts_by_naf_data",
         "waste_processed_by_naf_annual_stats",
     ]:

--- a/src/stats/processors/create_df.py
+++ b/src/stats/processors/create_df.py
@@ -23,3 +23,15 @@ def build_dataframes():
     bsd_data.all_bsds_data.write_json("temp_data/all_bsds_data.json")
     get_company_data().write_json("temp_data/company_data.json")
     get_user_data().write_json("temp_data/user_data.json")
+
+    for dataset_name in [
+        "bsdd_weekly_data",
+        "bsda_weekly_data",
+        "bsff_weekly_data",
+        "bsdasri_weekly_data",
+        "accounts_weekly_data",
+        "annual_waste_processed_data",
+        "accounts_by_naf_data",
+        "waste_processed_by_naf_annual_stats",
+    ]:
+        getattr(bsd_data, dataset_name).write_parquet(f"temp_data/{dataset_name}.parquet")

--- a/src/stats/processors/create_df.py
+++ b/src/stats/processors/create_df.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 
-from data.data_extract import get_company_data, get_user_data
 from data.datasets import get_data_df
 
 

--- a/src/stats/processors/create_figs.py
+++ b/src/stats/processors/create_figs.py
@@ -107,6 +107,15 @@ def build_figs(year, clear_year=False):
     bsff_data_df = pl.read_json("temp_data/bsff_data.json")
     bsdasri_data_df = pl.read_json("temp_data/bsdasri_data.json")
 
+    bsdd_weekly_data_df = pl.read_parquet("temp_data/bsdd_weekly_data.parquet")
+    bsda_weekly_data_df = pl.read_parquet("temp_data/bsda_weekly_data.parquet")
+    bsff_weekly_data_df = pl.read_parquet("temp_data/bsff_weekly_data.parquet")
+    bsdasri_weekly_data_df = pl.read_parquet("temp_data/bsdasri_weekly_data.parquet")
+    accounts_weekly_data_df = pl.read_parquet("temp_data/accounts_weekly_data.parquet")
+    annual_waste_processed_data_df = pl.read_parquet("temp_data/annual_waste_processed_data.parquet")
+    accounts_by_naf_data_df = pl.read_parquet("temp_data/accounts_by_naf_data.parquet")
+    waste_processed_by_naf_annual_stats_df = pl.read_parquet("temp_data/waste_processed_by_naf_annual_stats.parquet")
+
     total_bs_created = get_total_bs_created(all_bsd_data)
     total_quantity_processed = get_total_quantity_processed(all_bsd_data)
     total_companies_created = company_data.height

--- a/src/stats/processors/create_figs.py
+++ b/src/stats/processors/create_figs.py
@@ -1,4 +1,5 @@
 import polars as pl
+from data.data_extract import get_processing_operation_codes_data
 
 from data.data_processing import (
     get_recovered_and_eliminated_quantity_processed_by_week_series,
@@ -177,8 +178,9 @@ def build_figs(year: int, clear_year: bool = False):
         recovered_quantity_series, eliminated_quantity_series, date_interval
     )
 
+    waste_codes_data = get_processing_operation_codes_data()
     quantity_processed_sunburst_fig = create_quantity_processed_sunburst_figure(
-        weekly_waste_processed_data_df, date_interval
+        weekly_waste_processed_data_df, waste_codes_data, date_interval
     )
 
     quantity_processed_yearly = get_total_quantity_processed(

--- a/src/stats/processors/create_figs.py
+++ b/src/stats/processors/create_figs.py
@@ -1,15 +1,11 @@
 import polars as pl
 
-from data.data_extract import get_naf_nomenclature_data
 from data.data_processing import (
-    get_quantities_by_naf,
     get_recovered_and_eliminated_quantity_processed_by_week_series,
     get_total_bs_created,
     get_total_number_of_accounts_created,
     get_total_quantity_processed,
-    get_waste_quantity_processed_by_processing_code_df,
     get_weekly_preprocessed_dfs,
-    get_weekly_waste_quantity_processed_by_operation_code_df,
 )
 from data.figures_factory import (
     create_quantity_processed_sunburst_figure,

--- a/src/templates/stats/stats.html
+++ b/src/templates/stats/stats.html
@@ -84,7 +84,7 @@
     <script>
         function renderPlots(plotConfigs) {
             for (let config of plotConfigs) {
-                let newConfig = {...config.data.config, locale: 'fr'}
+                let newConfig = {...config.data.config, locale: 'fr',displaylogo: false}
                 Plotly.newPlot(
                     config.target,
                     config.data.data,

--- a/src/templates/stats/yearly.html
+++ b/src/templates/stats/yearly.html
@@ -33,7 +33,7 @@
     <div class="fr-callout">
         <p class="callout-number small-number">{{ computation.bs_created_yearly|number }}</p>
         <div class="number-text">
-            <p>bordereaux créés sur l'année {{ computation.year }}</p>
+            <p>bordereaux de déchets dangereux* créés sur l'année {{ computation.year }}</p>
         </div>
     </div>
     <div class="fr-callout processing-explanation-block">


### PR DESCRIPTION
Les données des statistiques publiques sont maintenant pré-calculées dans l'entrepôt de données. Elles sont aussi mises à disposition en open data sur data.gouv.fr.
Afin d'avoir une seule source de données et garantir l'homogénéité des données publiées, cette PR retire les calculs de données de l'application des stats publiques pour récupérer directement les données pré-calculées de l'entrepôt de données.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-11988)
