### PR TITLE
Modification de la logique de calcul des statistiques annuelles

### DIFF
--- a/src/stats/management/commands/build_stats.py
+++ b/src/stats/management/commands/build_stats.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 from django.core.management.base import BaseCommand
 
 from ...processors.clear import clear_figs

--- a/src/stats/management/commands/build_stats.py
+++ b/src/stats/management/commands/build_stats.py
@@ -13,8 +13,8 @@ class Command(BaseCommand):
 
         clear_figs()
 
-        year = dt.date.today().year
+        # year = dt.date.today().year
         # build y-1 data if they don't exist
-        build_figs(year - 1, clear_year=True)
+        build_figs(2022, clear_year=True)
         # build current year data
-        build_figs(year, clear_year=True)
+        build_figs(2023, clear_year=True)

--- a/src/stats/urls.py
+++ b/src/stats/urls.py
@@ -1,10 +1,19 @@
 from django.urls import path
 
-from .views import BsdasriView, BsdaView, BsddView, BsffView, BsvhuView, CompanyView, CurrentStats, LastStats, UserView
+from .views import (
+    BaseRender,
+    BsdasriView,
+    BsdaView,
+    BsddView,
+    BsffView,
+    BsvhuView,
+    CompanyView,
+    UserView,
+)
 
 urlpatterns = [
-    path("stats-current", CurrentStats.as_view(), name="current_stats"),
-    path("stats-last", LastStats.as_view(), name="last_stats"),
+    path("stats/", BaseRender.as_view(), name="last_stats"),
+    path("stats/<int:year>", BaseRender.as_view(), name="yearly_stats"),
     path("bsdd/<int:year>", BsddView.as_view(), name="bsdd"),
     path("bsda/<int:year>", BsdaView.as_view(), name="bsda"),
     path("bsdasri/<int:year>", BsdasriView.as_view(), name="bsdasri"),

--- a/src/stats/views.py
+++ b/src/stats/views.py
@@ -11,9 +11,6 @@ from stats.models import Computation
 class BaseRender(TemplateView):
     template_name = "stats/yearly.html"
 
-    def handle_missing_computation(self, year):
-        pass
-
     def get_current_year(self):
         """Today's year"""
         return dt.date.today().year

--- a/src/templates/stats/stats.html
+++ b/src/templates/stats/stats.html
@@ -64,7 +64,7 @@
             </div>
             <hr>
             <div id="yearly_wrapper">
-                <div hx-get="{% url 'current_stats' %}"
+                <div hx-get="{% url 'yearly_stats' year=2023 %}"
                      hx-trigger="load"
                      hx-target="#yearly_wrapper"
                      hx-indicator="#yearly_spinner"></div>

--- a/src/templates/stats/yearly.html
+++ b/src/templates/stats/yearly.html
@@ -5,19 +5,19 @@
     <ul id="header-nav-elements-container" class="fr-nav__list">
         <li class="fr-nav__item">
             <span class="fr-nav__link"
-                  hx-get="{% url 'last_stats' %}"
+                  hx-get="{% url 'yearly_stats' year=2022 %}"
                   hx-trigger="click"
                   hx-target="#yearly_wrapper"
                   hx-indicator="#yearly_spinner"
-                  {% if current_year != computation.year %}aria-current="page"{% endif %}>Année {{ current_year|add:"-1" }}</span>
+                  {% if computation.year == 2022 %}aria-current="page"{% endif %}>Année 2022</span>
         </li>
         <li class="fr-nav__item">
             <span class="fr-nav__link"
-                  hx-get="{% url 'current_stats' %}"
+                  hx-get="{% url 'yearly_stats' year=2023 %}"
                   hx-trigger="click"
                   hx-target="#yearly_wrapper"
                   hx-indicator="#yearly_spinner"
-                  {% if current_year == computation.year %}aria-current="page"{% endif %}>Année {{ current_year }}</span>
+                  {% if computation.year == 2023 %}aria-current="page"{% endif %}>Année 2023</span>
         </li>
     </ul>
 </nav>


### PR DESCRIPTION
Auparavant l'obtention de l'année était dynamique. Dorénavant les années à calculer et qui sont affichées sont prédéfinies dans le code.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-13483)
