### PR TITLE
Correctif pour rendre la page plus "responsive"

### DIFF
--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -58,11 +58,11 @@
   grid-column: span 6;
 }
 
-.operation-type-section > div:nth-child(1) {
+.operation-type-section>div:nth-child(1) {
   grid-column: span 8;
 }
 
-.operation-type-section > div:nth-child(2) {
+.operation-type-section>div:nth-child(2) {
   grid-column: span 4;
 }
 
@@ -76,7 +76,7 @@
   display: none;
 }
 
-.spinner > div {
+.spinner>div {
   background-color: #333;
   height: 100%;
   width: 6px;
@@ -107,8 +107,13 @@
 }
 
 @-webkit-keyframes sk-stretchdelay {
-  0%, 40%, 100% { -webkit-transform: scaleY(0.4) }
-  20% { -webkit-transform: scaleY(1.0) }
+  0%, 40%, 100% {
+    -webkit-transform: scaleY(0.4)
+  }
+
+  20% {
+    -webkit-transform: scaleY(1.0)
+  }
 }
 
 @keyframes sk-stretchdelay {
@@ -116,6 +121,7 @@
     transform: scaleY(0.4);
     -webkit-transform: scaleY(0.4);
   }
+
   20% {
     transform: scaleY(1.0);
     -webkit-transform: scaleY(1.0);
@@ -143,10 +149,25 @@
 .accordion-content.active {
   display: block;
 }
-.fr-tabs
-{
+
+.fr-tabs {
   margin-bottom: 2rem;
 }
-.fr-tabs__panel{
+
+.fr-tabs__panel {
   border: 1px solid #dddddd;
+}
+
+/* LG screens*/
+@media screen and (max-width:992px) {
+  .fr-callout {
+    grid-column: span 6;
+  }
+}
+
+/* MD screens*/
+@media screen and (max-width:768px) {
+  .fr-callout {
+    grid-column: span 12;
+  }
 }

--- a/src/templates/stats/stats.html
+++ b/src/templates/stats/stats.html
@@ -84,7 +84,7 @@
     <script>
         function renderPlots(plotConfigs) {
             for (let config of plotConfigs) {
-                let newConfig = {...config.data.config, locale: 'fr',displaylogo: false}
+                let newConfig = {...config.data.config, locale: 'fr',displaylogo: false, responsive:true}
                 Plotly.newPlot(
                     config.target,
                     config.data.data,


### PR DESCRIPTION
Les graphes Plotly s'adaptent maintenant à la largeur de la page. Les callouts sont aussi redimensionnés selon les breakpoints définis dans le DSFR.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-13850)
