### PR TITLE
Enlève la mention de "dangereux"

### DIFF
--- a/src/templates/stats/yearly.html
+++ b/src/templates/stats/yearly.html
@@ -47,7 +47,7 @@
     <div class="fr-callout">
         <p class="callout-number small-number">{{ computation.bs_created_yearly|number|safe }}</p>
         <div class="number-text">
-            <p>bordereaux de déchets dangereux* créés sur l'année {{ computation.year }}</p>
+            <p>bordereaux créés sur l'année {{ computation.year }}</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Maintenant, le nombre de bordereaux sur l'année inclus les non dangereux. L'étiquette a été corrigée en conséquence.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-14513)
