### PR TITLE
Modification des règles de coloration des installations

### DIFF
--- a/src/static/js/map.js
+++ b/src/static/js/map.js
@@ -396,7 +396,7 @@ async function loadInstallations(year, rubrique) {
     ) {
       markerColor = "yellow"; 
     }else if (
-      (!annualRubriques.includes(selectedRubrique) && ((value["taux_consommation"] != null) && (value["taux_consommation"] <= 0.2)))
+      ((value["taux_consommation"] != null) && ((value["taux_consommation"] <= 0.2) || (value["taux_consommation"] >= 1)))
     ) {
       markerColor = "dark"; 
     } else {


### PR DESCRIPTION
Les règles ont été modifiés pour colorer en noir les installations qui dépassent leur quantité autorisée. Aussi cette règle ne fait plus la distinction rubrique annuelle vs rubrique journalière.

- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-15375)
