### PR TITLE
HOTFIX : Mise à jour de plotly.js

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -31,7 +31,7 @@
     <body>
         {% block main %}{% endblock %}
         <script src="{% static 'js/htmx.min.js' %}"></script>
-        <script src="{% static 'js/plotly-2.27.0.min.js' %}" charset="utf-8"></script>
+        <script src="{% static 'js/plotly-3.0.0.min.js' %}" charset="utf-8"></script>
         {% block scripts %}{% endblock %}
     </body>
 </html>

--- a/src/templates/map.html
+++ b/src/templates/map.html
@@ -29,7 +29,7 @@
         <script src="{% static 'js/leaflet.js' %}"
                 integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="></script>
         <script src="{% static 'js/d3.v7.min.js' %}"></script>
-        <script src="{% static 'js/plotly-2.27.0.min.js' %}" charset="utf-8"></script>
+        <script src="{% static 'js/plotly-3.0.0.min.js' %}" charset="utf-8"></script>
         <link rel="stylesheet" href="{% static 'css/map.css' %}" />
         <link rel="stylesheet" href="{% static 'css/style.css' %}" />
     </head>


### PR DESCRIPTION
La version de plotly.js n'était plus compatible avec celle de plotly python.

- [ ] Mettre à jour le change log
---

- [Ticket Favro]()
